### PR TITLE
[fix] ios에서 카카오톡 프로필 이미지가 노출되지 않던 문제 수정

### DIFF
--- a/src/frontend/odongdong/src/app/services/auth/login-service.ts
+++ b/src/frontend/odongdong/src/app/services/auth/login-service.ts
@@ -5,26 +5,26 @@ import axios from 'axios';
 import { environment } from 'src/environments/environment';
 
 @Injectable({
-  providedIn: 'root',
+    providedIn: 'root',
 })
 export class LoginService {
-  constructor(public navController: NavController) {}
+    constructor(public navController: NavController) {}
 
-  async kakaoLogin() {
-    location.replace(`${environment.apiUrl}/oauth2/authorization/kakao`);
-  }
-
-  async getUserProfile() {
-    try {
-      const response = await axios({
-        method: 'get',
-        url: `${environment.apiUrl}/api/user/profile`,
-        withCredentials: true,
-        responseType: 'json',
-      });
-      return response;
-    } catch (error) {
-      return error.response;
+    async kakaoLogin() {
+        location.replace(`${environment.apiUrl}/oauth2/authorization/kakao`);
     }
-  }
+
+    async getUserProfile() {
+        try {
+            const response = await axios({
+                method: 'get',
+                url: `${environment.apiUrl}/api/user/profile`,
+                withCredentials: true,
+                responseType: 'json',
+            });
+            return response;
+        } catch (error) {
+            return error.response;
+        }
+    }
 }

--- a/src/frontend/odongdong/src/app/services/image/image-service.ts
+++ b/src/frontend/odongdong/src/app/services/image/image-service.ts
@@ -1,9 +1,9 @@
-import { Injectable } from "@angular/core";
+import { Injectable } from '@angular/core';
 
 @Injectable({
     providedIn: 'root',
 })
-export class ImageService{
+export class ImageService {
     constructor() {}
 
     async b64toBlob(b64Data, contentType = '', sliceSize = 512) {
@@ -15,7 +15,7 @@ export class ImageService{
 
             const byteNumbers = new Array(slice.length);
             for (let i = 0; i < slice.length; i++) {
-            byteNumbers[i] = slice.charCodeAt(i);
+                byteNumbers[i] = slice.charCodeAt(i);
             }
 
             const byteArray = new Uint8Array(byteNumbers);
@@ -25,5 +25,9 @@ export class ImageService{
         const blob = new Blob(byteArrays, { type: contentType });
 
         return blob;
+    }
+
+    async httpToHttps(imageUrl: string) {
+        return imageUrl.replace('http', 'https');
     }
 }

--- a/src/frontend/odongdong/src/app/tabs/profile-tab/profile.page.html
+++ b/src/frontend/odongdong/src/app/tabs/profile-tab/profile.page.html
@@ -16,7 +16,7 @@
     </div>
 
     <ion-avatar *ngIf="userImage" class="profile-image__container">
-        <img class="profile-image__image" src="{{userImage}}" alt="profile-image" />
+        <img class="profile-image__image" src="{{ userImage }}" alt="profile-image" />
     </ion-avatar>
     <div *ngIf="!userImage" class="profile-image__container">
         <button class="profile-image__button" (click)="openSocialLogin()">로그인 하기</button>

--- a/src/frontend/odongdong/src/app/tabs/profile-tab/profile.page.ts
+++ b/src/frontend/odongdong/src/app/tabs/profile-tab/profile.page.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { ModalController, NavController } from '@ionic/angular';
 import { SocialLoginComponent } from 'src/app/modals/social-login/social-login.component';
 import { LoginService } from 'src/app/services/auth/login-service';
+import { ImageService } from 'src/app/services/image/image-service';
 
 @Component({
     selector: 'app-profile',
@@ -15,6 +16,7 @@ export class ProfilePage implements OnInit {
 
     constructor(
         public loginService: LoginService,
+        public imageService: ImageService,
         public navController: NavController,
         public modalController: ModalController,
     ) {}
@@ -41,7 +43,7 @@ export class ProfilePage implements OnInit {
             const { data } = await this.loginService.getUserProfile();
 
             if (data.code === 1000) {
-                this.setProfile(data.result);
+                await this.setProfile(data.result);
             } else {
                 this.openSocialLogin();
             }
@@ -50,10 +52,10 @@ export class ProfilePage implements OnInit {
         }
     }
 
-    setProfile(userData) {
+    async setProfile(userData) {
         this.userName = userData.name;
         this.userEmail = userData.email;
-        this.userImage = userData.picture;
+        this.userImage = await this.imageService.httpToHttps(userData.picture);
     }
 
     goToRegisterList() {


### PR DESCRIPTION
close #137 

이제 ios에서도 카카오톡 프로필 이미지가 잘 뜰겁니다

`https`로 되어 있는 사이트에서 `http`로 시작하는 이미지를 렌더링 하는걸 막는데, 따로 경고나 깨지는 것 없이 바로 엑박으로 뜨게 만들고 있었습니다.

따라서 http => https로 변경해서 해결했습니다.