### PR TITLE
거리에 따라 화장실 정보를 불러올 범위를 지정합니다.

### DIFF
--- a/src/frontend/src/app/components/distance-filter/distance-filter.component.html
+++ b/src/frontend/src/app/components/distance-filter/distance-filter.component.html
@@ -1,0 +1,17 @@
+<div class="marker-filter__container">
+  <ion-select
+    placeholder="필터"
+    class="marker-filter__filter"
+    [(ngModel)]="currentFilterValue"
+    (ionChange)="filterChanged($event)"
+    aria-label="distance-options"
+  >
+    <ion-select-option
+      *ngFor="let distance of distanceOptions"
+      class="marker-filter__filter--item"
+      value="{{ distance }}"
+    >
+      내 주변 {{ distance }}
+    </ion-select-option>
+  </ion-select>
+</div>

--- a/src/frontend/src/app/components/distance-filter/distance-filter.component.scss
+++ b/src/frontend/src/app/components/distance-filter/distance-filter.component.scss
@@ -1,0 +1,33 @@
+* {
+  z-index: 5;
+}
+
+.marker-filter {
+  &__container {
+    position: fixed;
+    top: 2%;
+    left: 2%;
+
+    width: fit-content;
+    height: max-content;
+
+    text-align: right;
+
+    border-radius: 10px;
+
+    padding: 0 15px;
+
+    background-color: var(--bg_white);
+  }
+
+  &__filter {
+    font-size: 12px;
+
+    &--item {
+      position: fixed;
+      right: 2%;
+
+      font-size: 12px;
+    }
+  }
+}

--- a/src/frontend/src/app/components/distance-filter/distance-filter.component.spec.ts
+++ b/src/frontend/src/app/components/distance-filter/distance-filter.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { IonicModule } from '@ionic/angular';
+
+import { DistanceFilterComponent } from './distance-filter.component';
+
+describe('DistanceFilterComponent', () => {
+  let component: DistanceFilterComponent;
+  let fixture: ComponentFixture<DistanceFilterComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [DistanceFilterComponent],
+      imports: [IonicModule.forRoot()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DistanceFilterComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/frontend/src/app/components/distance-filter/distance-filter.component.ts
+++ b/src/frontend/src/app/components/distance-filter/distance-filter.component.ts
@@ -1,0 +1,21 @@
+import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+
+@Component({
+  selector: 'app-distance-filter',
+  templateUrl: './distance-filter.component.html',
+  styleUrls: ['./distance-filter.component.scss'],
+})
+export class DistanceFilterComponent implements OnInit {
+  @Output() filterValue = new EventEmitter<{ value: string }>();
+
+  public currentFilterValue = '1km';
+  public distanceOptions = ['500m', '1km', '2km'];
+
+  constructor() {}
+
+  ngOnInit() {}
+
+  filterChanged(event: any) {
+    this.filterValue.emit({ value: event.target?.value });
+  }
+}

--- a/src/frontend/src/app/components/distance-filter/distance-filter.module.ts
+++ b/src/frontend/src/app/components/distance-filter/distance-filter.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+import { IonicModule } from '@ionic/angular';
+
+import { DistanceFilterComponent } from './distance-filter.component';
+
+@NgModule({
+  imports: [CommonModule, FormsModule, IonicModule],
+  declarations: [DistanceFilterComponent],
+  exports: [DistanceFilterComponent],
+})
+export class DistanceFilterComponentModule {}

--- a/src/frontend/src/app/services/bathroomService.ts
+++ b/src/frontend/src/app/services/bathroomService.ts
@@ -5,6 +5,11 @@ import { LatLng } from '../types/location';
 import { BathroomInfo } from '../types/bathroomInfo';
 import { createFormData } from '../utils/bathroomData';
 import { ApiResponse } from '../types/response';
+import { DistanceOptionValues } from '../types/distance';
+
+interface GetBathroomProps extends LatLng {
+  distance: DistanceOptionValues;
+}
 
 @Injectable({
   providedIn: 'root',
@@ -12,13 +17,14 @@ import { ApiResponse } from '../types/response';
 export class BathroomService {
   constructor(private commonService: CommonService) {}
 
-  async get1kmBathroomList({
+  async getBathrooms({
     latitude,
     longitude,
-  }: LatLng): Promise<ApiResponse> {
+    distance,
+  }: GetBathroomProps): Promise<ApiResponse> {
     try {
       const response = await customAxios.get(
-        `api/bathroom/list?latitude=${latitude}&longitude=${longitude}&distance=1`
+        `api/bathroom/list?latitude=${latitude}&longitude=${longitude}&distance=${distance}`
       );
       return response;
     } catch (error) {

--- a/src/frontend/src/app/tabs/main/main.module.ts
+++ b/src/frontend/src/app/tabs/main/main.module.ts
@@ -7,6 +7,7 @@ import { MainPage } from './main.page';
 import { MainPageRoutingModule } from './main-routing.module';
 import { AddBathroomComponentModule } from 'src/app/components/add-bathroom/add-bathroom.component.module';
 import { BathroomDetailComponentModule } from 'src/app/components/bathroom-detail/bathroom-detail.component.module';
+import { DistanceFilterComponentModule } from 'src/app/components/distance-filter/distance-filter.module';
 
 @NgModule({
   imports: [
@@ -16,6 +17,7 @@ import { BathroomDetailComponentModule } from 'src/app/components/bathroom-detai
     MainPageRoutingModule,
     AddBathroomComponentModule,
     BathroomDetailComponentModule,
+    DistanceFilterComponentModule,
   ],
   declarations: [MainPage],
 })

--- a/src/frontend/src/app/tabs/main/main.page.html
+++ b/src/frontend/src/app/tabs/main/main.page.html
@@ -1,5 +1,5 @@
 <div id="container" class="container">
-  <!-- <app-data-filter (filterValue)="onFilterChanged($event)"></app-data-filter> -->
+  <app-distance-filter (filterValue)="onFilterChanged($event)" />
   <div id="map" class="map"></div>
   <div #detailContainer class="container__detail" *ngIf="markerClicked">
     <app-bathroom-detail [bathroomInfo]="bathroomInfo"></app-bathroom-detail>

--- a/src/frontend/src/app/tabs/main/main.page.scss
+++ b/src/frontend/src/app/tabs/main/main.page.scss
@@ -2,6 +2,8 @@
   width: 100%;
   height: 100%;
 
+  position: relative;
+
   .map {
     display: inline-block;
     position: absolute;

--- a/src/frontend/src/app/tabs/main/main.page.ts
+++ b/src/frontend/src/app/tabs/main/main.page.ts
@@ -12,6 +12,7 @@ import { AddBathroomComponent } from 'src/app/components/add-bathroom/add-bathro
 import { BathroomService } from 'src/app/services/bathroomService';
 import { CommonService } from 'src/app/services/commonService';
 import { BathroomDetailInfo } from 'src/app/types/bathroomInfo';
+import { Distance, DistanceOptions } from 'src/app/types/distance';
 import {
   createMarkerImage,
   deleteAllMarkers,
@@ -49,6 +50,7 @@ export class MainPage implements AfterViewInit {
 
   public bathroomList: Partial<BathroomDetailInfo>[];
   public bathroomInfo: any;
+  public bathroomRadius = '1km';
 
   public defaultMarkerIcon: any;
   public clickedMarkerIcon: any;
@@ -555,5 +557,10 @@ export class MainPage implements AfterViewInit {
 
   refresh() {
     window.location.reload();
+  }
+
+  onFilterChanged(event: { value: DistanceOptions }) {
+    this.bathroomRadius = event.value;
+    console.log('current data', this.bathroomRadius);
   }
 }

--- a/src/frontend/src/app/tabs/main/main.page.ts
+++ b/src/frontend/src/app/tabs/main/main.page.ts
@@ -50,7 +50,7 @@ export class MainPage implements AfterViewInit {
 
   public bathroomList: Partial<BathroomDetailInfo>[];
   public bathroomInfo: any;
-  public bathroomRadius = '1km';
+  public bathroomRadius: DistanceOptions = '1km';
 
   public defaultMarkerIcon: any;
   public clickedMarkerIcon: any;
@@ -109,9 +109,10 @@ export class MainPage implements AfterViewInit {
   }
 
   async getBathroomList() {
-    const response = await this.bathroomService.get1kmBathroomList({
+    const response = await this.bathroomService.getBathrooms({
       latitude: this.currentLat,
       longitude: this.currentLng,
+      distance: Distance[this.bathroomRadius],
     });
 
     if (response.data.code === 1000) {
@@ -133,9 +134,10 @@ export class MainPage implements AfterViewInit {
     setTimeout(async () => {
       const currentCenter = this.map.getCenter();
 
-      const response = await this.bathroomService.get1kmBathroomList({
+      const response = await this.bathroomService.getBathrooms({
         latitude: currentCenter._lat,
         longitude: currentCenter._lng,
+        distance: Distance[this.bathroomRadius],
       });
       if (response.data.code === 1000) {
         this.bathroomList = response.data.result as any;

--- a/src/frontend/src/app/types/distance.ts
+++ b/src/frontend/src/app/types/distance.ts
@@ -1,0 +1,8 @@
+export type DistanceOptions = '0.5' | '1' | '2';
+
+export const Distance = {
+  '500m': 0.5,
+  '1km': 1,
+  '2km': 2,
+};
+Object.freeze(Distance);

--- a/src/frontend/src/app/types/distance.ts
+++ b/src/frontend/src/app/types/distance.ts
@@ -1,6 +1,7 @@
-export type DistanceOptions = '0.5' | '1' | '2';
+export type DistanceOptions = '500m' | '1km' | '2km';
+export type DistanceOptionValues = 0.5 | 1 | 2;
 
-export const Distance = {
+export const Distance: Record<DistanceOptions, DistanceOptionValues> = {
   '500m': 0.5,
   '1km': 1,
   '2km': 2,


### PR DESCRIPTION
![image](https://github.com/Team-odongdong/odongdong/assets/59170680/017a5f73-eb48-4886-8ed7-b5cd44beac0e)

화면 좌측 상단에서 화장실을 불러올 범위를 지정할 수 있습니다.
거리는 0.5km, 1km, 2km 를 가져올 수 있습니다.

### 고민할 점들
2km반경의 화장실들을 불러오는 경우 0.2초 이상이 걸립니다. 거리를 조정할지, 프론트에서 최적화를 통해 해결할지 논의해봐야 할 듯 합니다.