### PR TITLE
feat: add distance info on detail page

### DIFF
--- a/src/frontend/src/app/components/bathroom-detail/bathroom-detail.component.html
+++ b/src/frontend/src/app/components/bathroom-detail/bathroom-detail.component.html
@@ -5,7 +5,10 @@
 >
   <div class="container__header">
     <div class="title">
-      <p class="title__name">{{ bathroomName }}</p>
+      <div class="flex">
+        <p class="title__name">{{ bathroomName }}</p>
+        <p class="title__distance">{{ distance }}m</p>
+      </div>
       <div class="title__rate">
         <app-rating
           [readonly]="true"

--- a/src/frontend/src/app/components/bathroom-detail/bathroom-detail.component.scss
+++ b/src/frontend/src/app/components/bathroom-detail/bathroom-detail.component.scss
@@ -25,6 +25,17 @@
         width: max-content;
       }
 
+      &__distance {
+        color: var(--outline_gray);
+        font-size: 12px;
+
+        margin: 0;
+        margin-top: 1.2rem;
+        margin-left: 0.25rem;
+
+        width: max-content;
+      }
+
       &__rate {
         margin-top: 0.5rem;
         margin-bottom: 0.875rem;
@@ -160,4 +171,9 @@ ion-img {
   height: 1.25rem;
 
   margin-left: 0.1875rem;
+}
+
+.flex {
+  display: flex;
+  justify-content: flex-end;
 }

--- a/src/frontend/src/app/components/bathroom-detail/bathroom-detail.component.ts
+++ b/src/frontend/src/app/components/bathroom-detail/bathroom-detail.component.ts
@@ -9,6 +9,7 @@ import {
 import { BathroomService } from 'src/app/services/bathroomService';
 import { CommonService } from 'src/app/services/commonService';
 import { BathroomDetailInfo } from 'src/app/types/bathroomInfo';
+import { roundDistance } from 'src/app/utils/formatting';
 
 @Component({
   selector: 'app-bathroom-detail',
@@ -29,6 +30,7 @@ export class BathroomDetailComponent implements OnInit {
   public address: string;
   public isOpened: string;
   public isUnisex = false;
+  public distance: number;
 
   public extended = false;
 
@@ -60,16 +62,17 @@ export class BathroomDetailComponent implements OnInit {
     return info;
   }
 
-  setBathroomDetailInfo(bathroonInfo: BathroomDetailInfo) {
-    this.bathroomId = bathroonInfo.id;
-    this.bathroomName = bathroonInfo.title;
-    this.rate = bathroonInfo.rate;
-    this.isLocked = bathroonInfo.isLocked;
-    this.operationTime = bathroonInfo.operationTime;
-    this.address = bathroonInfo.address + ' ' + this.bathroomInfo.addressDetail;
-    this.imageUrl = bathroonInfo.imageUrl;
-    this.isOpened = bathroonInfo.isOpened;
-    this.isUnisex = bathroonInfo.isUnisex;
+  setBathroomDetailInfo(bathroomInfo: BathroomDetailInfo) {
+    this.bathroomId = bathroomInfo.id;
+    this.bathroomName = bathroomInfo.title;
+    this.rate = bathroomInfo.rate;
+    this.isLocked = bathroomInfo.isLocked;
+    this.operationTime = bathroomInfo.operationTime;
+    this.address = bathroomInfo.address + ' ' + this.bathroomInfo.addressDetail;
+    this.imageUrl = bathroomInfo.imageUrl;
+    this.isOpened = bathroomInfo.isOpened;
+    this.isUnisex = bathroomInfo.isUnisex;
+    this.distance = roundDistance(bathroomInfo.distance);
   }
 
   onRatingChange(event: any) {

--- a/src/frontend/src/app/tabs/main/main.page.ts
+++ b/src/frontend/src/app/tabs/main/main.page.ts
@@ -527,6 +527,7 @@ export class MainPage implements AfterViewInit {
       isUnisex: data.isUnisex,
       latitude: data.latitude,
       longitude: data.longitude,
+      distance: data.distance,
     };
 
     return info;
@@ -563,6 +564,5 @@ export class MainPage implements AfterViewInit {
 
   onFilterChanged(event: { value: DistanceOptions }) {
     this.bathroomRadius = event.value;
-    console.log('current data', this.bathroomRadius);
   }
 }

--- a/src/frontend/src/app/types/bathroomInfo.ts
+++ b/src/frontend/src/app/types/bathroomInfo.ts
@@ -14,4 +14,5 @@ export interface BathroomDetailInfo extends BathroomInfo {
   id: number;
   isOpened: string;
   operationTime: string;
+  distance: number;
 }

--- a/src/frontend/src/app/utils/formatting.ts
+++ b/src/frontend/src/app/utils/formatting.ts
@@ -3,3 +3,7 @@ export const timeToHourAndMinute = (time: string) => {
 
   return time.match(regexp)?.[0];
 };
+
+export const roundDistance = (d: number) => {
+  return Math.round(d);
+};


### PR DESCRIPTION
아래 사진들과 같이, 소수점 첫번째 자리에서 반올림한 거리 정보가 노출됩니다.

![image](https://github.com/Team-odongdong/odongdong/assets/59170680/3eff93ff-746d-44c9-9fec-d07d91cf3b28)

![image](https://github.com/Team-odongdong/odongdong/assets/59170680/d4c9cc95-ce87-46e1-8928-7bffd0f45d83)
